### PR TITLE
Don't return classes outside of the target package

### DIFF
--- a/src/spiffworkflow_proxy/plugin_service.py
+++ b/src/spiffworkflow_proxy/plugin_service.py
@@ -84,7 +84,7 @@ class PluginService:
             if ispkg and name == package_name:
                 sub_pkg = finder.find_module(name).load_module(name)
                 yield from PluginService.modules_for_plugin_in_package(sub_pkg, None)
-            else:
+            elif package_name is None:
                 spec = finder.find_spec(name)
                 if spec is not None and spec.loader is not None:
                     module = types.ModuleType(spec.name)

--- a/tests/mock_connectors/connector-example/src/connector_example/someHelper.py
+++ b/tests/mock_connectors/connector-example/src/connector_example/someHelper.py
@@ -1,0 +1,4 @@
+class SomeHelper:
+    """SomeHelper class, should not be returned as a command or auth."""
+    def _execute(self, paramA, paramB):
+        pass


### PR DESCRIPTION
There was a bug if a connector had a class outside of `commands` or `auths`, it would be collected and returned along with the expected classes. This could be seen in `spiff-arena` where `postgres/BaseCommand` would appear as an auth and as a type for service tasks. The fix is to only return classes once we are in the desired sub package. Added an example helper class to the mock connector to help test.