### PR TITLE
do not use command http_status as top level status w/ burnettk

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,9 +47,11 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
@@ -66,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up python ${{ matrix.python-version }}
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -80,7 +82,7 @@ jobs:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/src/spiffworkflow_proxy/blueprint.py
+++ b/src/spiffworkflow_proxy/blueprint.py
@@ -71,8 +71,7 @@ def do_command(plugin_display_name: str, command_name: str) -> Response:
 
     if is_async_call:
         response = json.dumps(result)
-        status_code = result.get("command_response", {}).get("http_status", 200) if isinstance(result, dict) else 200
-        return Response(response, mimetype='application/json', status=status_code)
+        return Response(response, mimetype='application/json', status=202)
     elif "command_response_version" in result and result["command_response_version"] > 1:  # type: ignore
         response = json.dumps(result)
         return Response(response, mimetype='application/json', status=200)

--- a/tests/mock_connectors/connector-example/src/connector_example/commands/async_body_status.py
+++ b/tests/mock_connectors/connector-example/src/connector_example/commands/async_body_status.py
@@ -1,0 +1,29 @@
+"""Async command used by connector proxy tests."""
+from typing import Any
+
+from spiffworkflow_connector_command.command_interface import ConnectorProxyResponseDict
+
+
+class AsyncBodyStatus:
+    """Returns a body-level http_status from execute_async."""
+
+    def __init__(self, upstream_status: int = 500):
+        self.upstream_status = upstream_status
+
+    def execute(self, _config: Any, _task_data: Any) -> ConnectorProxyResponseDict:
+        return {
+            "command_response_version": 2,
+            "command_response": {
+                "body": {"started": False},
+                "mimetype": "application/json",
+                "http_status": self.upstream_status,
+            },
+            "error": {
+                "error_code": "AsyncStartRejected",
+                "message": "The async command rejected the start request.",
+            },
+            "spiff__logs": [],
+        }
+
+    def execute_async(self, _config: Any, _task_data: Any, callback_url: str) -> ConnectorProxyResponseDict:
+        return self.execute(_config, {"callback_url": callback_url})

--- a/tests/spiffworkflow_proxy/integration/blueprint_test.py
+++ b/tests/spiffworkflow_proxy/integration/blueprint_test.py
@@ -28,9 +28,9 @@ def test_list_commands() -> None:
     assert rv.status_code == 200
     # using rv.get_json() was giving me a "weakly-referenced object no longer exists". :/
     json_resp = json.loads(rv.get_data(as_text=True))
-    assert(len(json_resp) == 1)
-    assert(json_resp[0]["id"] == "example/CombineStrings")
-    assert(len(json_resp[0]["parameters"]) == 2)
+    commands_by_id = {command["id"]: command for command in json_resp}
+    assert(set(commands_by_id.keys()) == {"example/AsyncBodyStatus", "example/CombineStrings"})
+    assert(len(commands_by_id["example/CombineStrings"]["parameters"]) == 2)
 
 
 def test_do_command_ignores_spiff_params() -> None:
@@ -49,3 +49,18 @@ def test_do_command_ignores_spiff_params() -> None:
     json_resp = json.loads(rv.get_data(as_text=True))
     assert json_resp["command_response"]["body"]["command_response"]["arg1"] == "hello"
     assert json_resp["command_response"]["body"]["command_response"]["arg2"] == "world"
+
+
+def test_async_command_always_returns_accepted_status() -> None:
+    payload = {
+        "upstream_status": 500,
+        "spiff__callback_url": "http://localhost/callback",
+        "spiff__task_data": {"example": True},
+    }
+
+    rv = web_client().post("/v1/do/example/AsyncBodyStatus", json=payload)
+
+    assert rv.status_code == 202
+    json_resp = json.loads(rv.get_data(as_text=True))
+    assert json_resp["command_response"]["http_status"] == 500
+    assert json_resp["error"]["error_code"] == "AsyncStartRejected"

--- a/tests/spiffworkflow_proxy/unit/plugin_service_test.py
+++ b/tests/spiffworkflow_proxy/unit/plugin_service_test.py
@@ -19,4 +19,4 @@ def test_plugin_for_display_name() -> None:
 
 def test_available_commands_by_plugin() -> None:
     commands = PluginService.available_commands_by_plugin()
-    assert(list(commands['connector_example'].keys()) == ['CombineStrings'])
+    assert(set(commands['connector_example'].keys()) == {'AsyncBodyStatus', 'CombineStrings'})


### PR DESCRIPTION
This updates the support for async tasks so that if a command has an `execute_async` method, it will always return a 202 but spiff-arena will check for errors before backgrounding it.